### PR TITLE
継続状況を表示するカレンダーを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,5 @@ gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "jwt", "~> 2.7"
 
 gem "ransack", "~> 4.4"
+
+gem "simple_calendar", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,8 @@ GEM
       websocket (~> 1.0)
     sendgrid-ruby (6.7.0)
       ruby_http_client (~> 3.4)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -473,6 +475,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   selenium-webdriver (~> 4.27.0)
   sendgrid-ruby (~> 6.7)
+  simple_calendar (~> 3.1)
   sprockets-rails
   stimulus-rails
   tailwindcss-rails (~> 4.4)

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,35 @@
+class CalendarsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @habits = current_user.habits
+    @habit = params[:habit_id] ? current_user.habits.find(params[:habit_id]) : @habits.first
+
+    if @habit
+      @habit_checks = @habit.habit_checks
+        .order(:checked_on)
+        .group_by(&:checked_on)
+
+      @reopen_dates = calculate_reopen_dates
+    end
+  end
+
+  private
+
+  def calculate_reopen_dates
+    sorted_checks = @habit.habit_checks.order(:checked_on)
+    reopen_dates = []
+
+    sorted_checks.each_with_index do |check, i|
+      next unless check.all_achieved? || check.minimum_achieved?
+      next if i == 0
+
+      prev_check = sorted_checks[i - 1]
+      if !(prev_check.all_achieved? || prev_check.minimum_achieved?) || (check.checked_on - prev_check.checked_on) > 1
+        reopen_dates << check.checked_on
+      end
+    end
+
+    reopen_dates
+  end
+end

--- a/app/controllers/habit_checks_controller.rb
+++ b/app/controllers/habit_checks_controller.rb
@@ -3,21 +3,23 @@ class HabitChecksController < ApplicationController
   before_action :set_habit
 
   def new
-    today_check = @habit.habit_checks.find_by(checked_on: Date.today)
+    @date = params[:date] ? Date.parse(params[:date]) : Date.today
+    today_check = @habit.habit_checks.find_by(checked_on: @date)
     if today_check
       redirect_to edit_habit_habit_check_path(@habit, today_check)
       return
     end
-    @habit_check = @habit.habit_checks.build(checked_on: Date.today)
+    @habit_check = @habit.habit_checks.build(checked_on: @date)
     authorize @habit_check
   end
 
   def create
     @habit_check = @habit.habit_checks.new(habit_check_params)
-    @habit_check.checked_on = Date.today
+    @habit_check.checked_on = params[:habit_check][:checked_on] || Date.today
+    @date = @habit_check.checked_on
     authorize @habit_check
     if @habit_check.save
-      redirect_to home_path, notice: "チェックを記録しました"
+      redirect_to after_save_path, notice: "チェックを記録しました"
     else
       render :new, status: :unprocessable_entity
     end
@@ -32,7 +34,7 @@ class HabitChecksController < ApplicationController
     @habit_check = @habit.habit_checks.find(params[:id])
     authorize @habit_check
     if @habit_check.update(habit_check_params)
-      redirect_to home_path, notice: "チェックを更新しました"
+      redirect_to after_save_path, notice: "チェックを更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -45,6 +47,10 @@ class HabitChecksController < ApplicationController
   end
 
   def habit_check_params
-    params.require(:habit_check).permit(:evaluation, :exception_content, :exception_condition, :memo)
+    params.require(:habit_check).permit(:evaluation, :exception_content, :exception_condition, :memo, :checked_on)
+  end
+
+  def after_save_path
+    params[:from] == "calendar" ? calendar_path(habit_id: @habit.id) : home_path
   end
 end

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,0 +1,2 @@
+module CalendarsHelper
+end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -23,12 +23,16 @@ class Habit < ApplicationRecord
 
     sorted_checks.each_with_index do |check, i|
       next unless achieved?(check)
+      prev_check = sorted_checks[i - 1]
 
-      # 全て・最低目標達成で+1pt、前回の習慣チェックが未達成で+2pt（初日は1pt固定）
-      if i == 0 || achieved?(sorted_checks[i - 1])
+      if i == 0
+        # 初日は1pt固定
         score += 1
-      else
+      elsif !achieved?(prev_check) || (check.checked_on - prev_check.checked_on) > 1
+        # 前回チェックが未達成、または前回チェックから2日以上経過した場合は+2pt
         score += 2
+      else
+        score += 1
       end
     end
 
@@ -47,12 +51,16 @@ class Habit < ApplicationRecord
       # 達成した日の前回の習慣チェックを取得
       prev_check = sorted_checks.select { |hc| hc.checked_on < check.checked_on }.last
 
-      # 前回の習慣チェックがない（初日）または達成していれば+1pt
-      # 週の初日でも再開で+2ptになる場合がある
-      if prev_check.nil? || achieved?(prev_check)
+      if prev_check.nil?
+        # 前回のチェックがない（初日）
         score += 1
-      else
+      elsif !achieved?(prev_check) || (check.checked_on - prev_check.checked_on) > 1
+        # 前回のチェックが未達成または前回チェックから2日以上経過した場合は+2pt
+        # 週の初日でも再開で+2ptになる場合がある
         score += 2
+      else
+        # 前回のチェックが達成
+        score += 1
       end
     end
 

--- a/app/models/habit_check.rb
+++ b/app/models/habit_check.rb
@@ -15,4 +15,8 @@ class HabitCheck < ApplicationRecord
       "room_for_growth" => "伸びしろあり"
     }[evaluation]
   end
+
+  def start_time
+    checked_on.to_time
+  end
 end

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,0 +1,102 @@
+<% content_for :header do %>
+  <nav class="navbar bg-base-100 border-b border-base-200">
+    <div class="max-w-xl mx-auto w-full flex justify-center">
+      <span class="text-lg font-medium">カレンダー</span>
+    </div>
+  </nav>
+<% end %>
+
+<div class="px-6 py-8 bg-base-200 min-h-screen">
+  <div class="max-w-xl mx-auto space-y-4">
+
+    <%# 習慣選択 %>
+    <% if @habits.empty? %>
+      <div class="card bg-base-100 border border-base-200">
+        <div class="card-body p-6 text-center">
+          <p class="text-sm text-base-content/60">習慣がまだ登録されていません。</p>
+          <%= link_to "最初の習慣を登録する", new_habit_path, class: "btn btn-primary btn-sm mt-3" %>
+        </div>
+      </div>
+    <% else %>
+      <%= form_with url: calendar_path, method: :get, data: { turbo_frame: "_top" } do |f| %>
+        <div class="flex gap-2">
+          <%= f.select :habit_id,
+              @habits.map { |h| [h.title, h.id] },
+              { selected: @habit&.id },
+              class: "select select-bordered flex-1",
+              onchange: "this.form.submit()" %>
+          <%= f.hidden_field :year, value: @year %>
+          <%= f.hidden_field :month, value: @month %>
+        </div>
+      <% end %>
+
+      <%# カレンダー %>
+      <% if @habit %>
+        <div class="card bg-base-100 border border-base-200">
+          <div class="card-body p-5">
+
+            <%= month_calendar(events: @habit_checks&.values&.flatten || []) do |date, checks| %>
+              <%
+                check = checks.first
+                is_reopen = @reopen_dates&.include?(date)
+                bg_class = if check.nil?
+                  "bg-base-200"
+                elsif check.all_achieved?
+                  "bg-success/30"
+                elsif check.minimum_achieved?
+                  "bg-info/30"
+                elsif check.exception?
+                  "bg-warning/30"
+                else
+                  "bg-base-300"
+                end
+                today_class = date == Date.today ? "ring-2 ring-primary" : ""
+                reopen_class = is_reopen ? "ring-2 ring-warning" : ""
+                is_future = date > Date.today
+              %>
+              <% if is_future %>
+                <div class="aspect-square rounded-md <%= bg_class %> flex items-center justify-center">
+                  <span class="text-xs text-base-content/30"><%= date.day %></span>
+                </div>
+              <% elsif check %>
+                <%= link_to edit_habit_habit_check_path(@habit, check, from: "calendar"), class: "aspect-square rounded-md #{bg_class} #{today_class} #{reopen_class} flex items-center justify-center block" do %>
+                  <span class="text-xs font-medium"><%= date.day %></span>
+                <% end %>
+              <% else %>
+                <%= link_to new_habit_habit_check_path(@habit, date: date, from: "calendar"), class: "aspect-square rounded-md #{bg_class} #{today_class} flex items-center justify-center block" do %>
+                  <span class="text-xs text-base-content/50"><%= date.day %></span>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <%# 凡例 %>
+            <div class="flex flex-wrap gap-3 mt-4">
+              <div class="flex items-center gap-1">
+                <div class="w-3 h-3 rounded bg-success/30"></div>
+                <span class="text-xs text-base-content/60">全て達成</span>
+              </div>
+              <div class="flex items-center gap-1">
+                <div class="w-3 h-3 rounded bg-info/30"></div>
+                <span class="text-xs text-base-content/60">最低目標達成</span>
+              </div>
+              <div class="flex items-center gap-1">
+                <div class="w-3 h-3 rounded bg-warning/30"></div>
+                <span class="text-xs text-base-content/60">例外で未達成</span>
+              </div>
+              <div class="flex items-center gap-1">
+                <div class="w-3 h-3 rounded bg-base-300"></div>
+                <span class="text-xs text-base-content/60">伸びしろあり</span>
+              </div>
+              <div class="flex items-center gap-1">
+                <div class="w-3 h-3 rounded ring-2 ring-warning"></div>
+                <span class="text-xs text-base-content/60">再開（+2pt）</span>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/habit_checks/_form.html.erb
+++ b/app/views/habit_checks/_form.html.erb
@@ -17,7 +17,7 @@
         <span class="text-sm">全ての習慣を達成</span>
       </label>
       <label class="flex items-center gap-3 cursor-pointer">
-        <%= f.radio_button :evaluation, :minimum_achieved, class: "radio radio-primary" %>
+        <%= f.radio_button :evaluation, :minimum_achieved, class: "radio radio-info" %>
         <span class="text-sm">最低目標を達成</span>
       </label>
       <label class="flex items-center gap-3 cursor-pointer">
@@ -46,5 +46,9 @@
     <%= f.text_area :memo, rows: 3, class: "textarea textarea-bordered w-full" %>
   </div>
 
+  <%= f.hidden_field :checked_on, value: habit_check.checked_on %>
+  <% if params[:from] %>
+    <%= hidden_field_tag :from, params[:from] %>
+  <% end %>
   <%= f.submit habit_check.new_record? ? "登録" : "更新", class: "btn btn-primary w-full" %>
 <% end %>

--- a/app/views/habit_checks/edit.html.erb
+++ b/app/views/habit_checks/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :header do %>
   <nav class="navbar bg-base-100 border-b border-base-200">
     <div class="max-w-xl mx-auto w-full flex justify-center">
-      <span class="text-lg font-medium">習慣チェック　<%= Date.today.strftime("%Y年%m月%d日") %></span>
+      <span class="text-lg font-medium">習慣チェック　<%= @habit_check.checked_on.strftime("%Y年%m月%d日") %></span>
     </div>
   </nav>
 <% end %>

--- a/app/views/habit_checks/new.html.erb
+++ b/app/views/habit_checks/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :header do %>
   <nav class="navbar bg-base-100 border-b border-base-200">
     <div class="max-w-xl mx-auto w-full flex justify-center">
-      <span class="text-lg font-medium">習慣チェック　<%= Date.today.strftime("%Y年%m月%d日") %></span>
+      <span class="text-lg font-medium">習慣チェック　<%= @date.strftime("%Y年%m月%d日") %></span>
     </div>
   </nav>
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,6 +3,7 @@
     <div class="flex gap-6">
       <%= link_to "ホーム", home_path, class: "text-sm text-base-content/70 hover:text-base-content" %>
       <%= link_to "振り返り", reviews_path, class: "text-sm text-base-content/70 hover:text-base-content" %>
+      <%= link_to "カレンダー", calendar_path, class: "text-sm text-base-content/70 hover:text-base-content" %>
       <%= link_to "使い方", guide_path, class: "text-sm text-base-content/70 hover:text-base-content" %>
     </div>
     <%= link_to "設定", settings_path, class: "text-sm text-base-content/70 hover:text-base-content" %>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,24 @@
+<div class="simple-calendar">
+  <%# 月ナビゲーション %>
+  <div class="flex items-center justify-between mb-4">
+    <%= link_to "前月", calendar.url_for_previous_view, class: "btn btn-outline btn-sm" %>
+    <span class="text-sm font-medium"><%= start_date.strftime("%Y年%m月") %></span>
+    <%= link_to "次月", calendar.url_for_next_view, class: "btn btn-outline btn-sm" %>
+  </div>
+
+  <%# 曜日ヘッダー %>
+  <div class="grid grid-cols-7 gap-1 mb-2">
+    <% date_range.first(7).each do |day| %>
+      <div class="text-center text-xs text-base-content/50 font-medium py-1">
+        <%= %w[日 月 火 水 木 金 土][day.wday] %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# カレンダーグリッド %>
+  <div class="grid grid-cols-7 gap-1">
+    <% date_range.each do |day| %>
+      <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title">
+      <%= t('simple_calendar.week', default: 'Week') %>
+      <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module KachaKachaRoutine
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.beginning_of_week = :sunday
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   post "contact", to: "contacts#create"
   get "settings", to: "settings#index"
   patch "settings", to: "settings#update"
+  get "calendar", to: "calendars#index"
 
   resources :habits do
     resources :habit_checks, only: [ :new, :create, :edit, :update ]

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Habit, type: :model do
       create(:habit_check, habit: habit, checked_on: Date.today - 1, evaluation: :all_achieved)
       expect(habit.total_points).to eq(3)
     end
+
+    it "前回チェックから2日以上経過した場合は+2ptを返す" do
+      create(:habit_check, habit: habit, checked_on: Date.today - 3, evaluation: :all_achieved)
+      create(:habit_check, habit: habit, checked_on: Date.today - 1, evaluation: :all_achieved)
+      expect(habit.total_points).to eq(3)
+    end
   end
 
   describe "習慣数の上限" do

--- a/spec/system/calendars_spec.rb
+++ b/spec/system/calendars_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "カレンダー", type: :system do
+  let(:user) { create(:user) }
+  let(:habit) { create(:habit, user: user) }
+
+  before do
+    login_as user, scope: :user
+  end
+
+  it "カレンダー画面が表示される" do
+    visit calendar_path
+    expect(page).to have_content "カレンダー"
+  end
+
+  it "習慣を選択するとカレンダーが表示される" do
+    habit
+    visit calendar_path
+    expect(page).to have_content habit.title
+  end
+
+  it "チェック済みの日付をクリックすると編集画面に遷移する" do
+    habit_check = create(:habit_check, habit: habit, checked_on: Date.today)
+    visit calendar_path(habit_id: habit.id)
+    find("a[href*='habit_checks/#{habit_check.id}/edit']").click
+    expect(page).to have_content "習慣チェック"
+  end
+
+  it "過去の未チェック日付をクリックすると新規チェック画面に遷移する" do
+    habit
+    visit calendar_path(habit_id: habit.id)
+    past_date = Date.today - 1.day
+    find("a[href*='date=#{past_date}']").click
+    expect(page).to have_content "習慣チェック"
+  end
+end


### PR DESCRIPTION
習慣チェックした内容がGitHubのようにカレンダーに記録される。
習慣の評価によって色が変わる。

- [x] simple_calendarの導入
- [x] 画面のビュー作成
- [x] ルーティング設定
- [x] カレンダーを追加して継続状況を表示
- [x] 習慣チェック画面へのリンクを追加