### PR TITLE
ユーザアカウント削除機能を追加

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -13,6 +13,12 @@ class SettingsController < ApplicationController
     end
   end
 
+  def delete_account
+    current_user.destroy
+    reset_session
+    redirect_to root_path, notice: "アカウントを削除しました"
+  end
+
   private
 
   def settings_params

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -139,5 +139,12 @@
       </div>
     </div>
 
+    <%# アカウント削除 %>
+    <div class="card bg-base-100 border border-base-200">
+      <div class="card-body p-5">
+        <%= button_to "アカウントを削除する", delete_account_path, method: :delete, class: "btn btn-outline btn-error w-full", data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は取り消せません。" } %>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   post "contact", to: "contacts#create"
   get "settings", to: "settings#index"
   patch "settings", to: "settings#update"
+  delete "settings/delete_account", to: "settings#delete_account", as: :delete_account
   get "calendar", to: "calendars#index"
 
   resources :habits do

--- a/spec/system/settings_spec.rb
+++ b/spec/system/settings_spec.rb
@@ -70,4 +70,13 @@ RSpec.describe "設定", type: :system do
     click_button "設定を保存"
     expect(page).to have_content "設定を更新しました"
   end
+
+  it "アカウントを削除できる" do
+    visit settings_path
+    accept_confirm do
+      click_button "アカウントを削除する"
+    end
+    expect(page).to have_content "アカウントを削除しました"
+    expect(User.exists?(user.id)).to be_falsey
+  end
 end


### PR DESCRIPTION
このままだとプライベートな情報がサーバに残ってしまうため、ユーザアカウント削除機能を実装
- [x] ルーティング設定
- [x] アクション追加
- [x] 設定画面に削除ボタンを追加
- [x] RSpecの追加